### PR TITLE
Add Option to Limit FPS

### DIFF
--- a/Core.h
+++ b/Core.h
@@ -40,6 +40,7 @@ namespace LiveCoder {
 	
 const int DefaultWidth = 800;
 const int DefaultHeight = 600;
+const Uint32 DefaultMaxFrameRate = -1;
 
 const int EffectNum = 64;
 
@@ -72,6 +73,7 @@ private:
 	std::string nowSource;
 
 	Uint32 baseTime;
+	Uint32 minFrameTime;
 
 	float* audioBuffer;
 	GLuint audioTexture;
@@ -87,7 +89,7 @@ private:
 	GLuint optionTexture;
 public:
 
-	int Initialize(std::string title_, int width_, int height_, int SDLflags);
+	int Initialize(std::string title_, int width_, int height_, Uint32 maxFrameRate, int SDLflags);
 	int MainLoop();
 	void Render();
 

--- a/main.cpp
+++ b/main.cpp
@@ -7,18 +7,25 @@ int main(int argc, char** argv) {
 	int flags = SDL_OPENGL;
 	int width = 1280;
 	int height = 720;
+	int maxFrameRate = -1;
 
 	if (argc >= 2) {
-	  if (strcmp(argv[1], "-f") == 0) {
-	    flags = SDL_OPENGL | SDL_FULLSCREEN;
-	  }
+		for(int i = 1; i < argc; i++) {
+			if (strcmp(argv[i], "-f") == 0) {
+				flags = SDL_OPENGL | SDL_FULLSCREEN;
+			}
+			const char* fpsArgumentPrefix = "--fps=";
+			if (strncmp(argv[i], fpsArgumentPrefix, strlen(fpsArgumentPrefix)) == 0) {
+				maxFrameRate = atoi(argv[i]+strlen(fpsArgumentPrefix));
+			}
+		}
 	}
 	if (argc >= 4) {
 	  width = atoi(argv[2]);
 	  height = atoi(argv[3]);
 	}
 
-	if (core.Initialize("Live Coder", width, height, flags) < 0) {
+	if (core.Initialize("Live Coder", width, height, maxFrameRate, flags) < 0) {
 		return -1;
 	}
 	core.MainLoop();


### PR DESCRIPTION
Hi hole! Thanks for publishing this software.

One issue with it is by default it uses up 100% of CPU/GPU to render frames as fast as possible. This hogs resources from other software and can cause GPUs to unnecessarily spin up their cooling fans all the way. I want to fix that.

My pull request adds the option to specify `--fps=` on the command line to limit FPS to something more reasonable, such as a max of 60 frames per second with `--fps=60`. This fixes the excessive CPU/GPU use, and at 60 FPS there is no impact on how rapidly the software responds for most people as their monitors are naturally limited to 60fps (60 hertz). By default the option is disabled so the software can behave the same as it did before. It also still correctly parses the width/height and fullscreen options in combination with the fps option.

Please let me know if you have any questions!

Thanks